### PR TITLE
Fix logic bug affecting last hand

### DIFF
--- a/uno.py
+++ b/uno.py
@@ -461,24 +461,24 @@ if __name__ == "__main__":
                     if card[1:3] == "-D":
                         print_message(p.name + " played a Draw " + card[3:4])
                         draw24 = True
+
+		    # Check for UNO
+		    if p.num_cards() == 1:
+	                if p.said_uno:
+        	            print(Fore.YELLOW + "{} says UNO!!!" + Fore.RESET).format(p.name)
+                	    p.said_uno = False
+	                else:
+        	            print(Fore.YELLOW + "{} forgot to say UNO! Draw two!" + Fore.RESET).format(p.name)
+                            c, deck, discard_deck = draw_from_deck(deck, discard_deck)
+                            p.draw_card(c)
+                            c, deck, discard_deck = draw_from_deck(deck, discard_deck)
+                            p.draw_card(c)
+                            p.said_uno = False
                         
 
                 except:
                     print(Fore.RED + "Invalid card, try again. You played: {}" + Fore.RESET).format(card)
                     turn_over = False
-
-                # Check for UNO
-                if p.num_cards() == 1:
-                    if p.said_uno:
-                        print(Fore.YELLOW + "{} says UNO!!!" + Fore.RESET).format(p.name)
-                        p.said_uno = False
-                    else:
-                        print(Fore.YELLOW + "{} forgot to say UNO! Draw two!" + Fore.RESET).format(p.name)
-                        c, deck, discard_deck = draw_from_deck(deck, discard_deck)
-                        p.draw_card(c)
-                        c, deck, discard_deck = draw_from_deck(deck, discard_deck)
-                        p.draw_card(c)
-                        p.said_uno = False
 
             # Player is out of cards, so the game is over
             if p.num_cards() == 0:

--- a/uno.py
+++ b/uno.py
@@ -466,7 +466,6 @@ if __name__ == "__main__":
                 except:
                     print(Fore.RED + "Invalid card, try again. You played: {}" + Fore.RESET).format(card)
                     turn_over = False
-                    p.said_uno = False
 
                 # Check for UNO
                 if p.num_cards() == 1:


### PR DESCRIPTION
If you supplied an invalid input when playing your last card, the script would penalise you for having not said Uno, despite the fact that to reach that state, you *must* have said it the hand before, when you played your penultimate card, otherwise you would have drawn two cards.

Here is a screenshot with an example:![unobug](https://user-images.githubusercontent.com/1068110/35809660-4ee7fbbc-0a81-11e8-8fe9-7aad0045773c.png)

This is fixed by removing the p.said_uno reset during the processing of invalid inputs.